### PR TITLE
Disconnect expired clients on release

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -5,6 +5,15 @@ import socket
 import unittest
 
 
+try:
+    from unittest import mock  # noqa
+except ImportError:
+    try:
+        import mock  # noqa
+    except ImportError:
+        pass
+
+
 def test_redis_or_raise_skiptest(host="localhost", port=6379):
     s = socket.socket()
     try:

--- a/tornadis/pool.py
+++ b/tornadis/pool.py
@@ -152,8 +152,13 @@ class ClientPool(object):
         Args:
             client: Client object.
         """
-        if isinstance(client, Client) and not self._is_expired_client(client):
-            self.__pool.append(client)
+        if isinstance(client, Client):
+            if not self._is_expired_client(client):
+                LOG.debug('Client is not expired. Adding back to pool')
+                self.__pool.append(client)
+            elif client.is_connected():
+                LOG.debug('Client is expired and connected. Disconnecting')
+                client.disconnect()
         if self.__sem is not None:
             self.__sem.release()
 


### PR DESCRIPTION
After moving an app to use Tornadis, we started seeing connections leak.
We were using a pool of a limited size with a connection timeout. Since
the time deltas on connection state changes are calculated in
seconds, we tracked the connection leak down to
`ClientPool.release_client`. We found it possible for a client's
connection to expire while the client is in use most likely due to
rounding to whole seconds when calculating a client's freshness.
The client is never appended back to the pool allowing it to be
disconnected
[here](https://github.com/thefab/tornadis/blob/master/tornadis/pool.py#L62).

This change checks if the client is still connected if it's not placed
back into the pool and disconnects it.
