### PR TITLE
Handle ConnectionError on Client.call

### DIFF
--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -176,7 +176,9 @@ class ClientPoolTestCase(tornado.testing.AsyncTestCase):
 
     @tornado.testing.gen_test
     def test_release_expired_client_disconnect(self):
-        with mock.patch.object(ClientPool, '_is_expired_client', return_value=True):
+        with mock.patch.object(ClientPool,
+                               '_is_expired_client',
+                               return_value=True):
             c = ClientPool(max_size=5, client_timeout=60, autoclose=False)
             client = yield c.get_connected_client()
             self.assertTrue(client.is_connected())

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -7,7 +7,7 @@ import tornado.gen
 
 from tornadis.pubsub import PubSubClient
 from tornadis.client import Client
-from support import test_redis_or_raise_skiptest
+from support import test_redis_or_raise_skiptest, mock
 
 
 class PubSubClientTestCase(tornado.testing.AsyncTestCase):
@@ -93,3 +93,19 @@ class PubSubClientTestCase(tornado.testing.AsyncTestCase):
         res = yield c.pubsub_subscribe()
         self.assertFalse(res)
         c.disconnect()
+
+    @tornado.testing.gen_test
+    def test_subscribe_no_redis(self):
+        c = PubSubClient()
+        with mock.patch.object(c, "is_connected", return_value=False):
+            res = yield c.pubsub_subscribe("foo")
+            self.assertFalse(res)
+            self.assertFalse(c.subscribed)
+
+    @tornado.testing.gen_test
+    def test_unsubscribe_no_redis(self):
+        c = PubSubClient()
+        yield c.pubsub_subscribe("foo")
+        with mock.patch.object(c, "is_connected", return_value=False):
+            res = yield c.pubsub_unsubscribe("foo")
+            self.assertFalse(res)

--- a/tornadis/pubsub.py
+++ b/tornadis/pubsub.py
@@ -73,6 +73,8 @@ class PubSubClient(Client):
             raise tornado.gen.Return(False)
         results = yield Client.call(self, command, *args,
                                     __multiple_replies=len(args))
+        if isinstance(results, ConnectionError):
+            raise tornado.gen.Return(False)
         for reply in results:
             if isinstance(reply, ConnectionError) or len(reply) != 3 or \
                     reply[0].lower() != command.lower() or reply[2] == 0:
@@ -124,6 +126,8 @@ class PubSubClient(Client):
             args_len = len(args)
         results = yield Client.call(self, command, *args,
                                     __multiple_replies=args_len)
+        if isinstance(results, ConnectionError):
+            raise tornado.gen.Return(False)
         for reply in results:
             if isinstance(reply, ConnectionError) or len(reply) != 3 or \
                     reply[0].lower() != command.lower():


### PR DESCRIPTION
When redis is down Client.call may return ConnectionError (https://github.com/thefab/tornadis/blob/master/tornadis/client.py#L214) this patch adds a check to results variable in order to handle this case

(also, I had to make a small lint change in test_pool.py, as flake8 was complaning about it. However, it is just a formatting change)