### PR TITLE
Remove io_loop in tornado.ioloop.PeriodicCallback

### DIFF
--- a/tornadis/connection.py
+++ b/tornadis/connection.py
@@ -92,8 +92,7 @@ class Connection(object):
         self.unix_domain_socket = unix_domain_socket
         self._state = ConnectionState()
         self._ioloop = ioloop or tornado.ioloop.IOLoop.instance()
-        cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000,
-                                             self._ioloop)
+        cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000)
         self.__periodic_callback = cb
         self._read_callback = read_callback
         self._close_callback = close_callback


### PR DESCRIPTION
tornado versionchanged:: 5.0
       The ``io_loop`` argument (deprecated since version 4.1) has been removed.

@thefab, could you help to review and merge it? thanks.