### PR TITLE
Remove ioloop from PeriodicCallback #44

### DIFF
--- a/tornadis/connection.py
+++ b/tornadis/connection.py
@@ -92,8 +92,7 @@ class Connection(object):
         self.unix_domain_socket = unix_domain_socket
         self._state = ConnectionState()
         self._ioloop = ioloop or tornado.ioloop.IOLoop.instance()
-        cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000,
-                                             self._ioloop)
+        cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000)
         self.__periodic_callback = cb
         self._read_callback = read_callback
         self._close_callback = close_callback

--- a/tornadis/connection.py
+++ b/tornadis/connection.py
@@ -92,7 +92,12 @@ class Connection(object):
         self.unix_domain_socket = unix_domain_socket
         self._state = ConnectionState()
         self._ioloop = ioloop or tornado.ioloop.IOLoop.instance()
-        cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000)
+
+        if int(tornado.version[0]) >= 5:
+            cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000)
+        else:
+            cb = tornado.ioloop.PeriodicCallback(self._on_every_second, 1000, self._ioloop)
+
         self.__periodic_callback = cb
         self._read_callback = read_callback
         self._close_callback = close_callback


### PR DESCRIPTION
Changed in tornado version 5.0: The io_loop argument (deprecated since version 4.1) has been removed.
https://github.com/thefab/tornadis/issues/44