### PR TITLE
Updated docs to specifically say that tornado 6.0 is not supported

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -39,7 +39,7 @@ Go further: Pipeline
 Installation without pip
 ------------------------
 
-- install tornado_ >= 4.2
+- install tornado_  4.2 to 5.1.1 
 - install `python wrapper for hiredis`_
 - install six_
 - download and uncompress a `tornadis release`_


### PR DESCRIPTION
Tornado 6.0 removed tornado.gen.Task, which this package depends on.